### PR TITLE
Add avdevice support

### DIFF
--- a/device.go
+++ b/device.go
@@ -4,6 +4,6 @@ package astiav
 //#include <libavdevice/avdevice.h>
 import "C"
 
-func DeviceRegisterAll() {
+func RegisterAllDevices() {
 	C.avdevice_register_all()
 }

--- a/device.go
+++ b/device.go
@@ -1,0 +1,9 @@
+package astiav
+
+//#cgo pkg-config: libavdevice
+//#include <libavdevice/avdevice.h>
+import "C"
+
+func DeviceRegisterAll() {
+	C.avdevice_register_all()
+}

--- a/device_test.go
+++ b/device_test.go
@@ -6,5 +6,5 @@ import (
 )
 
 func TestDevice(t *testing.T) {
-	astiav.DeviceRegisterAll()
+	astiav.RegisterAllDevices()
 }

--- a/device_test.go
+++ b/device_test.go
@@ -1,0 +1,10 @@
+package astiav_test
+
+import (
+	"github.com/asticode/go-astiav"
+	"testing"
+)
+
+func TestDevice(t *testing.T) {
+	astiav.DeviceRegisterAll()
+}

--- a/input_format.go
+++ b/input_format.go
@@ -10,12 +10,6 @@ type InputFormat struct {
 	c *C.struct_AVInputFormat
 }
 
-func FindInputFormat(name string) *InputFormat {
-	cname := C.CString(name)
-	defer C.free(unsafe.Pointer(cname))
-	return newInputFormatFromC(C.av_find_input_format(cname))
-}
-
 func newInputFormatFromC(c *C.struct_AVInputFormat) *InputFormat {
 	if c == nil {
 		return nil
@@ -23,6 +17,25 @@ func newInputFormatFromC(c *C.struct_AVInputFormat) *InputFormat {
 	return &InputFormat{c: c}
 }
 
+func FindInputFormat(name string) *InputFormat {
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+	return newInputFormatFromC(C.av_find_input_format(cname))
+}
+
 func (f *InputFormat) Flags() IOFormatFlags {
 	return IOFormatFlags(f.c.flags)
+}
+
+func (f *InputFormat) Name() string {
+	return C.GoString(f.c.name)
+}
+
+// LongName Description of the format, meant to be more human-readable than Name.
+func (f *InputFormat) LongName() string {
+	return C.GoString(f.c.long_name)
+}
+
+func (f *InputFormat) String() string {
+	return f.Name()
 }

--- a/input_format.go
+++ b/input_format.go
@@ -3,10 +3,17 @@ package astiav
 //#cgo pkg-config: libavformat
 //#include <libavformat/avformat.h>
 import "C"
+import "unsafe"
 
 // https://github.com/FFmpeg/FFmpeg/blob/n5.0/libavformat/avformat.h#L650
 type InputFormat struct {
 	c *C.struct_AVInputFormat
+}
+
+func FindInputFormat(name string) *InputFormat {
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+	return newInputFormatFromC(C.av_find_input_format(cname))
 }
 
 func newInputFormatFromC(c *C.struct_AVInputFormat) *InputFormat {

--- a/input_format_test.go
+++ b/input_format_test.go
@@ -1,0 +1,12 @@
+package astiav_test
+
+import (
+	"github.com/asticode/go-astiav"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestFindInputFormat(t *testing.T) {
+	inputFormat := astiav.FindInputFormat("video4linux2")
+	require.True(t, inputFormat.Flags().Has(astiav.IOFormatFlagNoByteSeek))
+}

--- a/input_format_test.go
+++ b/input_format_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 )
 
-func TestFindInputFormat(t *testing.T) {
-	inputFormat := astiav.FindInputFormat("video4linux2")
-	require.True(t, inputFormat.Flags().Has(astiav.IOFormatFlagNoByteSeek))
+func TestInputFormat(t *testing.T) {
+	formatName := "rawvideo"
+	inputFormat := astiav.FindInputFormat(formatName)
+	require.NotNil(t, inputFormat)
+	require.True(t, inputFormat.Name() == formatName)
 }


### PR DESCRIPTION
Add avdevice support to turn on local cameras or other video devices.
Already tested with v4l2 on Linux, works great.
Example code:
```go
	astiav.RegisterAllDevices()
	dictionary := astiav.NewDictionary()
	dictionary.Set("pixel_format", "mjpeg", 0)
	dictionary.Set("framerate", "30", 0)
	dictionary.Set("video_size", "1920x1080", 0)
	inputFormat := astiav.FindInputFormat("video4linux2")
	formatContext := astiav.AllocFormatContext()
	err := formatContext.OpenInput("/dev/video0", inputFormat, dictionary)
	if err != nil {
		panic(err)
	}
	err = formatContext.FindStreamInfo(nil)
	if err != nil {
		panic(err)
	}
	pkt := astiav.AllocPacket()
	for {
		err = formatContext.ReadFrame(pkt)
		if err != nil {
			panic(err)
		}
		// jpeg data per frame
		data := pkt.Data()
		fmt.Println(len(data))
	}
```