### PR TITLE
Make planedata public

### DIFF
--- a/frame_data.go
+++ b/frame_data.go
@@ -44,7 +44,7 @@ func (d *FrameData) Bytes(align int) ([]byte, error) {
 	return nil, errors.New("astiav: frame type not implemented")
 }
 
-func (d *FrameData) planeData(i int, sizeFunc func(linesize int) int) []byte {
+func (d *FrameData) PlaneData(i int, sizeFunc func(linesize int) int) []byte {
 	return bytesFromC(func(size *cUlong) *C.uint8_t {
 		*size = cUlong(sizeFunc(int(d.f.c.linesize[i])))
 		return d.f.c.data[i]
@@ -70,7 +70,7 @@ func (d *FrameData) imageYCbCrSubsampleRatio() image.YCbCrSubsampleRatio {
 
 func (d *FrameData) imageNRGBA() *image.NRGBA {
 	return &image.NRGBA{
-		Pix:    d.planeData(0, func(linesize int) int { return linesize * d.f.Height() }),
+		Pix:    d.PlaneData(0, func(linesize int) int { return linesize * d.f.Height() }),
 		Stride: d.f.Linesize()[0],
 		Rect:   image.Rect(0, 0, d.f.Width(), d.f.Height()),
 	}
@@ -78,9 +78,9 @@ func (d *FrameData) imageNRGBA() *image.NRGBA {
 
 func (d *FrameData) imageYCbCr() *image.YCbCr {
 	return &image.YCbCr{
-		Y:              d.planeData(0, func(linesize int) int { return linesize * d.f.Height() }),
-		Cb:             d.planeData(1, func(linesize int) int { return linesize * d.f.Height() }),
-		Cr:             d.planeData(2, func(linesize int) int { return linesize * d.f.Height() }),
+		Y:              d.PlaneData(0, func(linesize int) int { return linesize * d.f.Height() }),
+		Cb:             d.PlaneData(1, func(linesize int) int { return linesize * d.f.Height() }),
+		Cr:             d.PlaneData(2, func(linesize int) int { return linesize * d.f.Height() }),
 		YStride:        d.f.Linesize()[0],
 		CStride:        d.f.Linesize()[1],
 		SubsampleRatio: d.imageYCbCrSubsampleRatio(),
@@ -91,7 +91,7 @@ func (d *FrameData) imageYCbCr() *image.YCbCr {
 func (d *FrameData) imageNYCbCrA() *image.NYCbCrA {
 	return &image.NYCbCrA{
 		YCbCr:   *d.imageYCbCr(),
-		A:       d.planeData(3, func(linesize int) int { return linesize * d.f.Height() }),
+		A:       d.PlaneData(3, func(linesize int) int { return linesize * d.f.Height() }),
 		AStride: d.f.Linesize()[3],
 	}
 }


### PR DESCRIPTION
The proposed change involves making the planeData method public, thereby allowing direct access to the underlying frame data.

This change would be bringing the possibility to create such functions like this below.

```go
func CopyIntoRgbaImage(f astiav.Frame, dstImage *image.RGBA) {
    requiredSize := f.Linesize()[0] * f.Height()
    
    // If the existing Pix slice is smaller than needed, allocate a new slice
    if len(dstImage.Pix) < requiredSize {
        dstImage.Pix = make([]byte, requiredSize)
    }

    // Copy pixel data
    copy(dstImage.Pix, f.Data().PlaneData(0, func(linesize int) int { return linesize * f.Height() }))

    // Update stride if different
    if dstImage.Stride != f.Linesize()[0] {
        dstImage.Stride = f.Linesize()[0]
    }

    // Update rect if different
    if dstImage.Rect.Dx() != f.Width() || dstImage.Rect.Dy() != f.Height() {
        dstImage.Rect = image.Rect(0, 0, f.Width(), f.Height())
    }
}
```