### PR TITLE
Enhance Codec Iteration and Checking of HardwareConfigMethodFlags

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -107,7 +107,7 @@ func FindEncoderByName(n string) *Codec {
 	return newCodecFromC(C.avcodec_find_encoder_by_name(cn))
 }
 
-func (c *Codec) HardwareConfigs(dt HardwareDeviceType) (configs []CodecHardwareConfig) {
+func (c *Codec) HardwareConfigs() (configs []CodecHardwareConfig) {
 	var i int
 	for {
 		config := C.avcodec_get_hw_config(c.c, C.int(i))
@@ -120,25 +120,9 @@ func (c *Codec) HardwareConfigs(dt HardwareDeviceType) (configs []CodecHardwareC
 	return
 }
 
-func (c *Codec) HasHardwareConfigMethodFlag(chcmf CodecHardwareConfigMethodFlag) bool {
-	var i C.int
-	for {
-		config := C.avcodec_get_hw_config(c.c, i)
-		if config == nil {
-			break
-		}
-
-		if (CodecHardwareConfig{c: config}.MethodFlags().Has(chcmf)) {
-			return true
-		}
-
-		i++
-	}
-	return false
-}
-
-func IterateCodecs(processor CodecProcessor) {
+func Codecs() []*Codec {
 	var opq *C.void = nil
+	var codecs []*Codec
 	for {
 		c := C.av_codec_iterate((*unsafe.Pointer)(unsafe.Pointer(&opq)))
 		if c == nil {
@@ -146,6 +130,7 @@ func IterateCodecs(processor CodecProcessor) {
 		}
 
 		codec := newCodecFromC(c)
-		processor(codec)
+		codecs = append(codecs, codec)
 	}
+	return codecs
 }

--- a/codec.go
+++ b/codec.go
@@ -13,8 +13,6 @@ type Codec struct {
 	c *C.struct_AVCodec
 }
 
-type CodecProcessor func(*Codec)
-
 func newCodecFromC(c *C.struct_AVCodec) *Codec {
 	if c == nil {
 		return nil

--- a/codec_test.go
+++ b/codec_test.go
@@ -10,6 +10,7 @@ import (
 func TestCodec(t *testing.T) {
 	c := astiav.FindDecoder(astiav.CodecIDMp3)
 	require.NotNil(t, c)
+	require.Equal(t, c.ID(), astiav.CodecIDMp3)
 	require.Nil(t, c.ChannelLayouts())
 	require.True(t, c.IsDecoder())
 	require.False(t, c.IsEncoder())
@@ -67,12 +68,11 @@ func TestCodec(t *testing.T) {
 	c = astiav.FindDecoderByName("invalid")
 	require.Nil(t, c)
 
-	var decoders []*astiav.Codec
-	processor := func(c *astiav.Codec) {
-		if c.IsDecoder() && c.ID() == astiav.CodecIDMjpeg {
-			decoders = append(decoders, c)
+	var found bool
+	for _, c := range astiav.Codecs() {
+		if c.ID() == astiav.CodecIDMjpeg {
+			found = true
 		}
 	}
-	astiav.IterateCodecs(processor)
-	require.Equal(t, decoders[0].ID(), astiav.CodecIDMjpeg)
+	require.True(t, found)
 }

--- a/codec_test.go
+++ b/codec_test.go
@@ -69,11 +69,10 @@ func TestCodec(t *testing.T) {
 
 	var decoders []*astiav.Codec
 	processor := func(c *astiav.Codec) {
-		if c.IsDecoder() && c.HasHardwareConfigMethodFlag(astiav.CodecHardwareConfigMethodFlagHwDeviceCtx) && c.ID() == astiav.CodecIDMjpeg {
+		if c.IsDecoder() && c.ID() == astiav.CodecIDMjpeg {
 			decoders = append(decoders, c)
 		}
 	}
 	astiav.IterateCodecs(processor)
 	require.Equal(t, decoders[0].ID(), astiav.CodecIDMjpeg)
-	require.True(t, decoders[0].HasHardwareConfigMethodFlag(astiav.CodecHardwareConfigMethodFlagHwDeviceCtx))
 }

--- a/codec_test.go
+++ b/codec_test.go
@@ -66,4 +66,14 @@ func TestCodec(t *testing.T) {
 
 	c = astiav.FindDecoderByName("invalid")
 	require.Nil(t, c)
+
+	var decoders []*astiav.Codec
+	processor := func(c *astiav.Codec) {
+		if c.IsDecoder() && c.HasHardwareConfigMethodFlag(astiav.CodecHardwareConfigMethodFlagHwDeviceCtx) && c.ID() == astiav.CodecIDMjpeg {
+			decoders = append(decoders, c)
+		}
+	}
+	astiav.IterateCodecs(processor)
+	require.Equal(t, decoders[0].ID(), astiav.CodecIDMjpeg)
+	require.True(t, decoders[0].HasHardwareConfigMethodFlag(astiav.CodecHardwareConfigMethodFlagHwDeviceCtx))
 }

--- a/examples/hardware_decoding/main.go
+++ b/examples/hardware_decoding/main.go
@@ -107,7 +107,7 @@ func main() {
 		defer s.decCodecContext.Free()
 
 		// Loop through codec hardware configs
-		for _, p := range s.decCodec.HardwareConfigs(hardwareDeviceType) {
+		for _, p := range s.decCodec.HardwareConfigs() {
 			// Valid hardware config
 			if p.MethodFlags().Has(astiav.CodecHardwareConfigMethodFlagHwDeviceCtx) && p.HardwareDeviceType() == hardwareDeviceType {
 				s.hardwarePixelFormat = p.PixelFormat()


### PR DESCRIPTION
Hey 

During intergration steps of hw decoding I see that some thing would be very handy.

**1. Hardware Configuration Flag Check:**
 A method HasHardwareConfigMethodFlag in the Codec struct allows checking if a codec supports a specific hardware configuration method. This is particularly useful for identifying if a codec is hardware accelerated.

Implementation snippet:
```go
func (c *Codec) HasHardwareConfigMethodFlag(chcmf CodecHardwareConfigMethodFlag) bool {
    var i C.int
    for {
        config := C.avcodec_get_hw_config(c.c, i)
        if config == nil {
            break
        }
        if (CodecHardwareConfig{c: config}.MethodFlags().Has(chcmf)) {
            return true
        }
        i++
    }
    return false
}
```


**2. Codec Iteration Enhancement:** 
A new function IterateCodecs simplifies the process of iterating over available codecs. This function takes a CodecProcessor and applies it to each codec, facilitating custom processing logic per codec.

Implementation snippet:
```go
func IterateCodecs(processor CodecProcessor) {
    var opq *C.void = nil
    for {
        c := C.av_codec_iterate((*unsafe.Pointer)(unsafe.Pointer(&opq)))
        if c == nil {
            break
        }
        codec := newCodecFromC(c)
        processor(codec)
    }
}
```


**3. Codec Identification:**
Added a method ID to the Codec struct to retrieve the codec's ID, aiding in the identification and filtering of codecs.
```go
func (c *Codec) ID() CodecID {
    return CodecID(c.c.id)
}
```

**Use Case**
These enhancements allow for efficient identification and selection of codecs based on capabilities and specific codec IDs. This is particularly useful in scenarios where an application needs to support multiple codecs across different operating systems and offers the user the ability to switch between different decoders.

A practical example of using these enhancements is shown below:
```go
var decoders []*astiav.Codec
processor := func(c *astiav.Codec) {
    if c.IsDecoder() && c.HasHardwareConfigMethodFlag(astiav.CodecHardwareConfigMethodFlagHwDeviceCtx) && c.ID() == astiav.CodecIDMjpeg {
        decoders = append(decoders, c)
    }
}
astiav.IterateCodecs(processor)
```

Br christoph