### PR TITLE
FFmpeg build: it clones only the required tag and skips documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,9 @@ generate-flags:
 
 install-ffmpeg:
 	rm -rf $(srcPath)
-	mkdir -p $(srcPath)
-	# cd $(srcPath) is necessary for windows build since otherwise git doesn't clone in the proper dir
-	cd $(srcPath) && git clone https://github.com/FFmpeg/FFmpeg $(srcPath)
-	cd $(srcPath) && git checkout $(version) $(postCheckout)
+	mkdir -p $(srcPath)	
+	# cd $(srcPath) prepend to the next command is necessary for windows build since otherwise git doesn't clone in the proper dir
+	git clone --depth 1 --branch $(version) https://github.com/FFmpeg/FFmpeg $(srcPath)
 	cd $(srcPath) && ./configure --prefix=.. $(configure)
 	cd $(srcPath) && make
 	cd $(srcPath) && make install

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ install-ffmpeg:
 	mkdir -p $(srcPath)	
 	# cd $(srcPath) prepend to the next command is necessary for windows build since otherwise git doesn't clone in the proper dir
 	git clone --depth 1 --branch $(version) https://github.com/FFmpeg/FFmpeg $(srcPath)
-	cd $(srcPath) && ./configure --prefix=.. $(configure)
+	cd $(srcPath) && ./configure --prefix=.. $(configure) \
+		--disable-htmlpages  --disable-doc --disable-txtpages --disable-podpages  --disable-manpages		
 	cd $(srcPath) && make
 	cd $(srcPath) && make install


### PR DESCRIPTION
It maybe useful for you, in any case I skipped the documentation because I was seeing the following error:

```
HTML doc/ffmpeg.html
makeinfo: error parsing ./doc/t2h.pm: Undefined subroutine &Texinfo::Config::set_from_init_file called at ./doc/t2h.pm line 24.
make: *** [doc/Makefile:70: doc/ffmpeg.html] Error 1 
```