### PR TITLE
add SetExtraData to CodecParameters to set extradata 

### DIFF
--- a/codec_parameters.go
+++ b/codec_parameters.go
@@ -145,6 +145,17 @@ func (cp *CodecParameters) SetSampleAspectRatio(r Rational) {
 	cp.c.sample_aspect_ratio = r.c
 }
 
+func (cp *CodecParameters) ExtraData() []byte {
+	return bytesFromC(func(size *C.size_t) *C.uint8_t {
+		if cp.c.extradata == nil {
+			*size = C.size_t(0)
+			return nil
+		}
+		*size = C.size_t(cp.c.extradata_size)
+		return cp.c.extradata
+	})
+}
+
 func (cp *CodecParameters) SetExtraData(extraData []byte) error {
 	if len(extraData) == 0 {
 		return nil
@@ -156,9 +167,8 @@ func (cp *CodecParameters) SetExtraData(extraData []byte) error {
 	}
 
 	extradataSize := len(extraData)
-	cp.c.extradata = (*C.uint8_t)(C.av_mallocz(C.size_t(extradataSize + C.AV_INPUT_BUFFER_PADDING_SIZE)))
-	if cp.c.extradata == nil {
-		return fmt.Errorf("failed to allocate extradata")
+	if cp.c.extradata = (*C.uint8_t)(C.av_mallocz(C.size_t(extradataSize + C.AV_INPUT_BUFFER_PADDING_SIZE))); cp.c.extradata == nil {
+		return fmt.Errorf("astiav: allocation is nil")
 	}
 
 	C.memcpy(unsafe.Pointer(cp.c.extradata), unsafe.Pointer(&extraData[0]), C.size_t(extradataSize))

--- a/codec_parameters_test.go
+++ b/codec_parameters_test.go
@@ -63,9 +63,6 @@ func TestCodecParameters(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 2, cp5.Channels())
 
-	err = cp5.SetExtraData([]byte{0, 0, 0, 1})
-	require.NoError(t, err)
-
 	cp6 := AllocCodecParameters()
 	require.NotNil(t, cp6)
 	defer cp6.Free()
@@ -98,4 +95,9 @@ func TestCodecParameters(t *testing.T) {
 	require.Equal(t, 4, cp6.SampleRate())
 	cp6.SetWidth(2)
 	require.Equal(t, 2, cp6.Width())
+
+	extraBytes := []byte{0, 0, 0, 1}
+	require.NoError(t, cp6.SetExtraData(extraBytes))
+	require.NoError(t, err)
+	require.Equal(t, extraBytes, cp6.ExtraData())
 }

--- a/codec_parameters_test.go
+++ b/codec_parameters_test.go
@@ -98,6 +98,5 @@ func TestCodecParameters(t *testing.T) {
 
 	extraBytes := []byte{0, 0, 0, 1}
 	require.NoError(t, cp6.SetExtraData(extraBytes))
-	require.NoError(t, err)
 	require.Equal(t, extraBytes, cp6.ExtraData())
 }

--- a/codec_parameters_test.go
+++ b/codec_parameters_test.go
@@ -63,6 +63,9 @@ func TestCodecParameters(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 2, cp5.Channels())
 
+	err = cp5.SetExtraData([]byte{0, 0, 0, 1})
+	require.NoError(t, err)
+
 	cp6 := AllocCodecParameters()
 	require.NotNil(t, cp6)
 	defer cp6.Free()


### PR DESCRIPTION
For publishing an rtmp stream extradata needs to be set (PPS, SPS h264).

