### PR TITLE
Add bit stream filter support

### DIFF
--- a/bit_stream_filter.go
+++ b/bit_stream_filter.go
@@ -25,3 +25,11 @@ func FindBitStreamFilterByName(n string) *BitStreamFilter {
 	defer C.free(unsafe.Pointer(cn))
 	return newBitStreamFilterFromC(C.av_bsf_get_by_name(cn))
 }
+
+func (bsf *BitStreamFilter) Name() string {
+	return C.GoString(bsf.c.name)
+}
+
+func (bsf *BitStreamFilter) String() string {
+	return bsf.Name()
+}

--- a/bit_stream_filter.go
+++ b/bit_stream_filter.go
@@ -17,8 +17,7 @@ func newBitStreamFilterFromC(c *C.struct_AVBitStreamFilter) *BitStreamFilter {
 	if c == nil {
 		return nil
 	}
-	cc := &BitStreamFilter{c: c}
-	return cc
+	return &BitStreamFilter{c: c}
 }
 
 func FindBitStreamFilterByName(n string) *BitStreamFilter {

--- a/bit_stream_filter.go
+++ b/bit_stream_filter.go
@@ -18,7 +18,6 @@ func newBitStreamFilterFromC(c *C.struct_AVBitStreamFilter) *BitStreamFilter {
 		return nil
 	}
 	cc := &BitStreamFilter{c: c}
-	classers.set(cc)
 	return cc
 }
 

--- a/bit_stream_filter.go
+++ b/bit_stream_filter.go
@@ -1,0 +1,29 @@
+package astiav
+
+//#cgo pkg-config: libavcodec
+//#include <libavcodec/bsf.h>
+//#include <stdlib.h>
+import "C"
+import (
+	"unsafe"
+)
+
+// https://github.com/FFmpeg/FFmpeg/blob/release/5.1/libavcodec/bsf.h#L111
+type BitStreamFilter struct {
+	c *C.struct_AVBitStreamFilter
+}
+
+func newBitStreamFilterFromC(c *C.struct_AVBitStreamFilter) *BitStreamFilter {
+	if c == nil {
+		return nil
+	}
+	cc := &BitStreamFilter{c: c}
+	classers.set(cc)
+	return cc
+}
+
+func FindBitStreamFilterByName(n string) *BitStreamFilter {
+	cn := C.CString(n)
+	defer C.free(unsafe.Pointer(cn))
+	return newBitStreamFilterFromC(C.av_bsf_get_by_name(cn))
+}

--- a/bit_stream_filter_context.go
+++ b/bit_stream_filter_context.go
@@ -1,0 +1,81 @@
+package astiav
+
+//#cgo pkg-config: libavcodec
+//#include <libavcodec/bsf.h>
+import "C"
+import (
+	"errors"
+	"unsafe"
+)
+
+// https://github.com/FFmpeg/FFmpeg/blob/release/5.1/libavcodec/bsf.h#L68
+type BSFContext struct {
+	c *C.struct_AVBSFContext
+}
+
+func newBSFContextFromC(c *C.struct_AVBSFContext) *BSFContext {
+	if c == nil {
+		return nil
+	}
+	bsfCtx := &BSFContext{c: c}
+	classers.set(bsfCtx)
+	return bsfCtx
+}
+
+var _ Classer = (*BSFContext)(nil)
+
+func AllocBitStreamContext(f *BitStreamFilter) (*BSFContext, error) {
+	if f == nil {
+		return nil, errors.New("astiav: bit stream filter must not be nil")
+	}
+
+	var bsfCtx *C.struct_AVBSFContext
+	if err := newError(C.av_bsf_alloc(f.c, &bsfCtx)); err != nil {
+		return nil, err
+	}
+
+	return newBSFContextFromC(bsfCtx), nil
+}
+
+func (bsfCtx *BSFContext) Class() *Class {
+	return newClassFromC(unsafe.Pointer(bsfCtx.c))
+}
+
+func (bsfCtx *BSFContext) Init() error {
+	return newError(C.av_bsf_init(bsfCtx.c))
+}
+
+func (bsfCtx *BSFContext) SendPacket(p *Packet) error {
+	if p == nil {
+		return errors.New("astiav: packet must not be nil")
+	}
+	return newError(C.av_bsf_send_packet(bsfCtx.c, p.c))
+}
+
+func (bsfCtx *BSFContext) ReceivePacket(p *Packet) error {
+	if p == nil {
+		return errors.New("astiav: packet must not be nil")
+	}
+	return newError(C.av_bsf_receive_packet(bsfCtx.c, p.c))
+}
+
+func (bsfCtx *BSFContext) Free() {
+	classers.del(bsfCtx)
+	C.av_bsf_free(&bsfCtx.c)
+}
+
+func (bsfCtx *BSFContext) TimeBaseIn() Rational {
+	return newRationalFromC(bsfCtx.c.time_base_in)
+}
+
+func (bsfCtx *BSFContext) SetTimeBaseIn(r Rational) {
+	bsfCtx.c.time_base_in = r.c
+}
+
+func (bsfCtx *BSFContext) CodecParametersIn() *CodecParameters {
+	return newCodecParametersFromC(bsfCtx.c.par_in)
+}
+
+func (bsfCtx *BSFContext) SetCodecParametersIn(cp *CodecParameters) {
+	bsfCtx.c.par_in = cp.c
+}

--- a/bit_stream_filter_context_test.go
+++ b/bit_stream_filter_context_test.go
@@ -34,7 +34,7 @@ func TestBitStreamFilterContext(t *testing.T) {
 
 	// video.mp4 bit stream h264 format is avcc
 	pkt1, err := globalHelper.inputFirstPacket("video.mp4")
-	pkt1Bsf, errBsf := globalHelper.inputFirstPacketWithBitStreamFilter("video.mp4", "h264_mp4toannexb")
+	pkt1Bsf, errBsf := globalHelper.inputFirstVideoPacketWithBitStreamFilter("video.mp4", "h264_mp4toannexb")
 	require.NoError(t, err)
 	require.NoError(t, errBsf)
 

--- a/bit_stream_filter_context_test.go
+++ b/bit_stream_filter_context_test.go
@@ -24,7 +24,6 @@ func TestBitStreamFilterContext(t *testing.T) {
 
 	cp1 := AllocCodecParameters()
 	require.NotNil(t, cp1)
-	defer cp1.Free()
 	cp1.SetCodecID(CodecIDH264)
 
 	bsfc.SetCodecParametersIn(cp1)

--- a/bit_stream_filter_context_test.go
+++ b/bit_stream_filter_context_test.go
@@ -12,7 +12,7 @@ func TestBitStreamFilterContext(t *testing.T) {
 
 	bsfc, err := AllocBitStreamFilterContext(bsf)
 	require.NotNil(t, bsfc)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer bsfc.Free()
 
 	cl := bsfc.Class()
@@ -22,21 +22,13 @@ func TestBitStreamFilterContext(t *testing.T) {
 	bsfc.SetTimeBaseIn(NewRational(15, 1))
 	require.Equal(t, NewRational(15, 1), bsfc.TimeBaseIn())
 
-	fc, err := globalHelper.inputFormatContext("video.mp4")
-	require.NoError(t, err)
-	ss := fc.Streams()
-	require.Len(t, ss, 2)
-	s1 := ss[0]
+	cp1 := AllocCodecParameters()
+	require.NotNil(t, cp1)
+	defer cp1.Free()
+	cp1.SetCodecID(CodecIDH264)
 
-	cp1 := s1.CodecParameters()
 	bsfc.SetCodecParametersIn(cp1)
-	require.Equal(t, int64(441324), bsfc.CodecParametersIn().BitRate())
+	require.Equal(t, CodecIDH264, bsfc.CodecParametersIn().CodecID())
 
-	// video.mp4 bit stream h264 format is avcc
-	pkt1, err := globalHelper.inputFirstPacket("video.mp4")
-	pkt1Bsf, errBsf := globalHelper.inputFirstVideoPacketWithBitStreamFilter("video.mp4", "h264_mp4toannexb")
-	require.NoError(t, err)
-	require.NoError(t, errBsf)
-
-	require.NotEqual(t, pkt1.Data(), pkt1Bsf.Data())
+	// TODO: add tests for send and receive packet flows
 }

--- a/bit_stream_filter_context_test.go
+++ b/bit_stream_filter_context_test.go
@@ -1,0 +1,42 @@
+package astiav
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBitStreamFilterContext(t *testing.T) {
+	bsf := FindBitStreamFilterByName("null")
+	require.NotNil(t, bsf)
+
+	bsfc, err := AllocBitStreamFilterContext(bsf)
+	require.NotNil(t, bsfc)
+	require.Nil(t, err)
+	defer bsfc.Free()
+
+	cl := bsfc.Class()
+	require.NotNil(t, cl)
+	require.Equal(t, "AVBSFContext", cl.Name())
+
+	bsfc.SetTimeBaseIn(NewRational(15, 1))
+	require.Equal(t, NewRational(15, 1), bsfc.TimeBaseIn())
+
+	fc, err := globalHelper.inputFormatContext("video.mp4")
+	require.NoError(t, err)
+	ss := fc.Streams()
+	require.Len(t, ss, 2)
+	s1 := ss[0]
+
+	cp1 := s1.CodecParameters()
+	bsfc.SetCodecParametersIn(cp1)
+	require.Equal(t, int64(441324), bsfc.CodecParametersIn().BitRate())
+
+	// video.mp4 bit stream h264 format is avcc
+	pkt1, err := globalHelper.inputFirstPacket("video.mp4")
+	pkt1Bsf, errBsf := globalHelper.inputFirstPacket("video.mp4", withBitStreamFilter("h264_mp4toannexb"))
+	require.NoError(t, err)
+	require.NoError(t, errBsf)
+
+	require.NotEqual(t, pkt1.Data(), pkt1Bsf.Data())
+}

--- a/bit_stream_filter_context_test.go
+++ b/bit_stream_filter_context_test.go
@@ -34,7 +34,7 @@ func TestBitStreamFilterContext(t *testing.T) {
 
 	// video.mp4 bit stream h264 format is avcc
 	pkt1, err := globalHelper.inputFirstPacket("video.mp4")
-	pkt1Bsf, errBsf := globalHelper.inputFirstPacket("video.mp4", withBitStreamFilter("h264_mp4toannexb"))
+	pkt1Bsf, errBsf := globalHelper.inputFirstPacketWithBitStreamFilter("video.mp4", "h264_mp4toannexb")
 	require.NoError(t, err)
 	require.NoError(t, errBsf)
 

--- a/bit_stream_filter_test.go
+++ b/bit_stream_filter_test.go
@@ -1,0 +1,21 @@
+package astiav
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBitStreamFilter(t *testing.T) {
+	bitStreamFilterNames := []string{"h264_mp4toannexb", "null", "setts"}
+
+	for _, fn := range bitStreamFilterNames {
+		f := FindBitStreamFilterByName(fn)
+		require.NotNil(t, f)
+		require.Equal(t, f.Name(), fn)
+		require.Equal(t, f.String(), fn)
+	}
+
+	f := FindBitStreamFilterByName("foobar_non_existing_bsf")
+	require.Nil(t, f)
+}

--- a/bit_stream_filter_test.go
+++ b/bit_stream_filter_test.go
@@ -7,15 +7,12 @@ import (
 )
 
 func TestBitStreamFilter(t *testing.T) {
-	bitStreamFilterNames := []string{"h264_mp4toannexb", "null", "setts"}
+	fn := "null"
+	f := FindBitStreamFilterByName(fn)
+	require.NotNil(t, f)
+	require.Equal(t, f.Name(), fn)
+	require.Equal(t, f.String(), fn)
 
-	for _, fn := range bitStreamFilterNames {
-		f := FindBitStreamFilterByName(fn)
-		require.NotNil(t, f)
-		require.Equal(t, f.Name(), fn)
-		require.Equal(t, f.String(), fn)
-	}
-
-	f := FindBitStreamFilterByName("foobar_non_existing_bsf")
+	f = FindBitStreamFilterByName("foobar_non_existing_bsf")
 	require.Nil(t, f)
 }


### PR DESCRIPTION
Add support to [Bit Stream Filter](https://ffmpeg.org/doxygen/5.1/group__lavc__bsf.html).

> Bitstream filters transform encoded media data without decoding it. This allows e.g. manipulating various header values. Bitstream filters operate on [AVPackets](https://ffmpeg.org/doxygen/5.1/structAVPacket.html).
>
> The bitstream filtering API is centered around two structures: [AVBitStreamFilter](https://ffmpeg.org/doxygen/5.1/structAVBitStreamFilter.html) and [AVBSFContext](https://ffmpeg.org/doxygen/5.1/structAVBSFContext.html). The former represents a bitstream filter in abstract, the latter a specific filtering process. Obtain an [AVBitStreamFilter](https://ffmpeg.org/doxygen/5.1/structAVBitStreamFilter.html) using [av_bsf_get_by_name()](https://ffmpeg.org/doxygen/5.1/group__lavc__bsf.html#gae491493190b45698ebd43db28c4e8fe9) or [av_bsf_iterate()](https://ffmpeg.org/doxygen/5.1/group__lavc__bsf.html#gaff3224f9026f829d25557cf85c9e9e12), then pass it to [av_bsf_alloc()](https://ffmpeg.org/doxygen/5.1/group__lavc__bsf.html#ga7da65af303e20c9546e15ec266b182c1) to create an [AVBSFContext](https://ffmpeg.org/doxygen/5.1/structAVBSFContext.html). [Fill](https://ffmpeg.org/doxygen/5.1/structFill.html) in the user-settable [AVBSFContext](https://ffmpeg.org/doxygen/5.1/structAVBSFContext.html) fields, as described in its documentation, then call [av_bsf_init()](https://ffmpeg.org/doxygen/5.1/group__lavc__bsf.html#ga242529d54013acf87e94273d298a5ff2) to prepare the filter context for use.
>
> Submit packets for filtering using [av_bsf_send_packet()](https://ffmpeg.org/doxygen/5.1/group__lavc__bsf.html#gaada9ea8f08d3dcf23c14564dbc88992c), obtain filtered results with [av_bsf_receive_packet()](https://ffmpeg.org/doxygen/5.1/group__lavc__bsf.html#ga7fffb6c87b91250956e7a2367af56b38). When no more input packets will be sent, submit a NULL [AVPacket](https://ffmpeg.org/doxygen/5.1/structAVPacket.html) to signal the end of the stream to the filter. [av_bsf_receive_packet()](https://ffmpeg.org/doxygen/5.1/group__lavc__bsf.html#ga7fffb6c87b91250956e7a2367af56b38) will then return trailing packets, if any are produced by the filter.
>
> Finally, free the filter context with [av_bsf_free()](https://ffmpeg.org/doxygen/5.1/group__lavc__bsf.html#ga08d53431e76355f88e27763b1940df4f).

src: https://github.com/FFmpeg/FFmpeg/blob/release/5.1/libavcodec/bsf.h