### PR TITLE
Fix transcoding example about timebase

### DIFF
--- a/examples/transcoding/main.go
+++ b/examples/transcoding/main.go
@@ -275,7 +275,7 @@ func openOutputFile() (err error) {
 			} else {
 				s.encCodecContext.SetSampleFormat(s.decCodecContext.SampleFormat())
 			}
-			s.encCodecContext.SetTimeBase(s.decCodecContext.TimeBase())
+			s.encCodecContext.SetTimeBase(astiav.NewRational(1, s.encCodecContext.SampleRate()))
 		} else {
 			s.encCodecContext.SetHeight(s.decCodecContext.Height())
 			if v := s.encCodec.PixelFormats(); len(v) > 0 {
@@ -284,7 +284,7 @@ func openOutputFile() (err error) {
 				s.encCodecContext.SetPixelFormat(s.decCodecContext.PixelFormat())
 			}
 			s.encCodecContext.SetSampleAspectRatio(s.decCodecContext.SampleAspectRatio())
-			s.encCodecContext.SetTimeBase(s.decCodecContext.TimeBase())
+			s.encCodecContext.SetTimeBase(s.decCodecContext.Framerate().Inv())
 			s.encCodecContext.SetWidth(s.decCodecContext.Width())
 		}
 
@@ -376,7 +376,7 @@ func initFilters() (err error) {
 			args = astiav.FilterArgs{
 				"pix_fmt":      strconv.Itoa(int(s.decCodecContext.PixelFormat())),
 				"pixel_aspect": s.decCodecContext.SampleAspectRatio().String(),
-				"time_base":    s.decCodecContext.TimeBase().String(),
+				"time_base":    s.decCodecContext.Framerate().Inv().String(),
 				"video_size":   strconv.Itoa(s.decCodecContext.Width()) + "x" + strconv.Itoa(s.decCodecContext.Height()),
 			}
 			buffersrc = astiav.FindFilterByName("buffer")

--- a/examples/transcoding/main.go
+++ b/examples/transcoding/main.go
@@ -376,9 +376,8 @@ func initFilters() (err error) {
 			args = astiav.FilterArgs{
 				"pix_fmt":      strconv.Itoa(int(s.decCodecContext.PixelFormat())),
 				"pixel_aspect": s.decCodecContext.SampleAspectRatio().String(),
-				//"time_base":    s.decCodecContext.Framerate().Invert().String(),
-				"time_base":  s.inputStream.TimeBase().String(),
-				"video_size": strconv.Itoa(s.decCodecContext.Width()) + "x" + strconv.Itoa(s.decCodecContext.Height()),
+				"time_base":    s.inputStream.TimeBase().String(),
+				"video_size":   strconv.Itoa(s.decCodecContext.Width()) + "x" + strconv.Itoa(s.decCodecContext.Height()),
 			}
 			buffersrc = astiav.FindFilterByName("buffer")
 			buffersink = astiav.FindFilterByName("buffersink")

--- a/examples/transcoding/main.go
+++ b/examples/transcoding/main.go
@@ -284,7 +284,7 @@ func openOutputFile() (err error) {
 				s.encCodecContext.SetPixelFormat(s.decCodecContext.PixelFormat())
 			}
 			s.encCodecContext.SetSampleAspectRatio(s.decCodecContext.SampleAspectRatio())
-			s.encCodecContext.SetTimeBase(s.decCodecContext.Framerate().Inv())
+			s.encCodecContext.SetTimeBase(s.decCodecContext.Framerate().Invert())
 			s.encCodecContext.SetWidth(s.decCodecContext.Width())
 		}
 
@@ -376,8 +376,9 @@ func initFilters() (err error) {
 			args = astiav.FilterArgs{
 				"pix_fmt":      strconv.Itoa(int(s.decCodecContext.PixelFormat())),
 				"pixel_aspect": s.decCodecContext.SampleAspectRatio().String(),
-				"time_base":    s.decCodecContext.Framerate().Inv().String(),
-				"video_size":   strconv.Itoa(s.decCodecContext.Width()) + "x" + strconv.Itoa(s.decCodecContext.Height()),
+				//"time_base":    s.decCodecContext.Framerate().Invert().String(),
+				"time_base":  s.inputStream.TimeBase().String(),
+				"video_size": strconv.Itoa(s.decCodecContext.Width()) + "x" + strconv.Itoa(s.decCodecContext.Height()),
 			}
 			buffersrc = astiav.FindFilterByName("buffer")
 			buffersink = astiav.FindFilterByName("buffersink")

--- a/rational.go
+++ b/rational.go
@@ -50,3 +50,7 @@ func (r Rational) String() string {
 	}
 	return strconv.Itoa(r.Num()) + "/" + strconv.Itoa(r.Den())
 }
+
+func (r Rational) Inv() Rational {
+	return NewRational(r.Den(), r.Num())
+}

--- a/rational.go
+++ b/rational.go
@@ -51,6 +51,6 @@ func (r Rational) String() string {
 	return strconv.Itoa(r.Num()) + "/" + strconv.Itoa(r.Den())
 }
 
-func (r Rational) Inv() Rational {
+func (r Rational) Invert() Rational {
 	return NewRational(r.Den(), r.Num())
 }

--- a/rational_test.go
+++ b/rational_test.go
@@ -10,6 +10,7 @@ func TestRational(t *testing.T) {
 	r := NewRational(2, 1)
 	require.Equal(t, 2, r.Num())
 	require.Equal(t, 1, r.Den())
+	require.Equal(t, 0.5, r.Invert().Float64())
 	r.SetNum(1)
 	r.SetDen(2)
 	require.Equal(t, 1, r.Num())


### PR DESCRIPTION
as-is:
The transcoding example does not work with your current testdata/video.mp4.

to-be: It should be made to work.

refer: https://www.ffmpeg.org/doxygen/trunk/transcode_8c-example.html

in official ffmpeg example 

```
/* In this example, we transcode to same properties (picture size,
             * sample rate etc.). These properties can be changed for output
             * streams easily using filters */
            if (dec_ctx->codec_type == AVMEDIA_TYPE_VIDEO) {
                enc_ctx->height = dec_ctx->height;
                enc_ctx->width = dec_ctx->width;
                enc_ctx->sample_aspect_ratio = dec_ctx->sample_aspect_ratio;
                /* take first format from list of supported formats */
                if (encoder->pix_fmts)
                    enc_ctx->pix_fmt = encoder->pix_fmts[0];
                else
                    enc_ctx->pix_fmt = dec_ctx->pix_fmt;
                /* video time_base can be set to whatever is handy and supported by encoder */
                enc_ctx->time_base = av_inv_q(dec_ctx->framerate); // HERE
            } else {
                enc_ctx->sample_rate = dec_ctx->sample_rate;
                ret = av_channel_layout_copy(&enc_ctx->ch_layout, &dec_ctx->ch_layout);
                if (ret < 0)
                    return ret;
                /* take first format from list of supported formats */
                enc_ctx->sample_fmt = encoder->sample_fmts[0];
                enc_ctx->time_base = (AVRational){1, enc_ctx->sample_rate}; // HERE
            }
```

I modified your example by referencing the C example.