### PR TITLE
Add hardware frame context for hardware video encoding

### DIFF
--- a/frame.go
+++ b/frame.go
@@ -33,6 +33,10 @@ func (f *Frame) AllocBuffer(align int) error {
 	return newError(C.av_frame_get_buffer(f.c, C.int(align)))
 }
 
+func (f *Frame) AllocHWBuffer(hfc *HardwareFrameContext, align int) error {
+	return newError(C.av_hwframe_get_buffer(hfc.c, f.c, C.int(align)))
+}
+
 func (f *Frame) AllocImage(align int) error {
 	return newError(C.av_image_alloc(&f.c.data[0], &f.c.linesize[0], f.c.width, f.c.height, (C.enum_AVPixelFormat)(f.c.format), C.int(align)))
 }

--- a/hardware_frame_context.go
+++ b/hardware_frame_context.go
@@ -1,0 +1,48 @@
+package astiav
+
+//#include <libavcodec/avcodec.h>
+import "C"
+import (
+	"fmt"
+	"unsafe"
+)
+
+type HardwareFrameContext struct {
+	c *C.struct_AVBufferRef
+}
+
+func AllocHardwareFrameContext(hdc *HardwareDeviceContext) (*HardwareFrameContext, error) {
+	if hfc := C.av_hwframe_ctx_alloc(hdc.c); hfc != nil {
+		return &HardwareFrameContext{c: hfc}, nil
+	}
+	return nil, fmt.Errorf("failed to allocate hardware frame context")
+}
+
+func (hfc *HardwareFrameContext) SetWidth(width int) {
+	frameCtx := (*C.AVHWFramesContext)(unsafe.Pointer((hfc.c.data)))
+	frameCtx.width = C.int(width)
+}
+
+func (hfc *HardwareFrameContext) SetHeight(height int) {
+	frameCtx := (*C.AVHWFramesContext)(unsafe.Pointer((hfc.c.data)))
+	frameCtx.height = C.int(height)
+}
+
+func (hfc *HardwareFrameContext) SetFormat(format PixelFormat) {
+	frameCtx := (*C.AVHWFramesContext)(unsafe.Pointer((hfc.c.data)))
+	frameCtx.format = C.enum_AVPixelFormat(format)
+}
+
+func (hfc *HardwareFrameContext) SetSWFormat(swFormat PixelFormat) {
+	frameCtx := (*C.AVHWFramesContext)(unsafe.Pointer((hfc.c.data)))
+	frameCtx.sw_format = C.enum_AVPixelFormat(swFormat)
+}
+
+func (hfc *HardwareFrameContext) SetInitialPoolSize(initialPoolSize int) {
+	frameCtx := (*C.AVHWFramesContext)(unsafe.Pointer((hfc.c.data)))
+	frameCtx.initial_pool_size = C.int(initialPoolSize)
+}
+
+func (hfc *HardwareFrameContext) Init() error {
+	return newError(C.av_hwframe_ctx_init(hfc.c))
+}


### PR DESCRIPTION
With the addition of hardware frame context, hardware video encoding can be achieved. The official vaapi_encode.c example can now be implemented in Go. I personally tried with CUDA and it works similar to vaapi.

This PR does not have UTs yet. Please help review the changes before I can proceed to write some UTs.