### PR TITLE
Support for io.EOF to C.AVERROR_EOF mapping

### DIFF
--- a/io_context.go
+++ b/io_context.go
@@ -6,6 +6,7 @@ import "C"
 import (
 	"errors"
 	"fmt"
+	"io"
 	"sync"
 	"unsafe"
 )
@@ -241,6 +242,8 @@ func goAstiavIOContextReadFunc(opaque unsafe.Pointer, buf *C.uint8_t, bufSize C.
 		var e Error
 		if errors.As(err, &e) {
 			return C.int(e)
+		} else if errors.Is(err, io.EOF) {
+			return C.int(C.AVERROR_EOF)
 		}
 		return C.AVERROR_UNKNOWN
 	}

--- a/io_context.go
+++ b/io_context.go
@@ -243,7 +243,7 @@ func goAstiavIOContextReadFunc(opaque unsafe.Pointer, buf *C.uint8_t, bufSize C.
 		if errors.As(err, &e) {
 			return C.int(e)
 		} else if errors.Is(err, io.EOF) {
-			return C.int(C.AVERROR_EOF)
+			return C.AVERROR_EOF
 		}
 		return C.AVERROR_UNKNOWN
 	}

--- a/io_context_test.go
+++ b/io_context_test.go
@@ -41,7 +41,7 @@ func TestIOContext(t *testing.T) {
 		require.Equal(t, wb, written)
 	})
 
-	t.Run("support go eof -> ffmpeg eof when reading", func(t *testing.T) {
+	t.Run("io.EOF is mapped to AVERROR_EOF when reading", func(t *testing.T) {
 		c, err := AllocIOContext(8, false, func(b []byte) (int, error) {
 			return 0, io.EOF
 		}, nil, nil)

--- a/io_context_test.go
+++ b/io_context_test.go
@@ -1,6 +1,7 @@
 package astiav
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,34 +10,48 @@ import (
 )
 
 func TestIOContext(t *testing.T) {
-	var seeked bool
-	rb := []byte("read")
-	wb := []byte("write")
-	var written []byte
-	c, err := AllocIOContext(8, true, func(b []byte) (int, error) {
-		copy(b, rb)
-		return len(rb), nil
-	}, func(offset int64, whence int) (n int64, err error) {
-		seeked = true
-		return offset, nil
-	}, func(b []byte) (int, error) {
-		written = make([]byte, len(b))
-		copy(written, b)
-		return len(b), nil
+	t.Run("read write seek", func(t *testing.T) {
+		var seeked bool
+		rb := []byte("read")
+		wb := []byte("write")
+		var written []byte
+		c, err := AllocIOContext(8, true, func(b []byte) (int, error) {
+			copy(b, rb)
+			return len(rb), nil
+		}, func(offset int64, whence int) (n int64, err error) {
+			seeked = true
+			return offset, nil
+		}, func(b []byte) (int, error) {
+			written = make([]byte, len(b))
+			copy(written, b)
+			return len(b), nil
+		})
+		require.NoError(t, err)
+		defer c.Free()
+		b := make([]byte, 6)
+		n, err := c.Read(b)
+		require.NoError(t, err)
+		require.Equal(t, 4, n)
+		require.Equal(t, rb, b[:n])
+		_, err = c.Seek(2, 0)
+		require.NoError(t, err)
+		require.True(t, seeked)
+		c.Write(wb)
+		c.Flush()
+		require.Equal(t, wb, written)
 	})
-	require.NoError(t, err)
-	defer c.Free()
-	b := make([]byte, 6)
-	n, err := c.Read(b)
-	require.NoError(t, err)
-	require.Equal(t, 4, n)
-	require.Equal(t, rb, b[:n])
-	_, err = c.Seek(2, 0)
-	require.NoError(t, err)
-	require.True(t, seeked)
-	c.Write(wb)
-	c.Flush()
-	require.Equal(t, wb, written)
+
+	t.Run("support go eof -> ffmpeg eof when reading", func(t *testing.T) {
+		c, err := AllocIOContext(8, false, func(b []byte) (int, error) {
+			return 0, io.EOF
+		}, nil, nil)
+		require.NoError(t, err)
+		defer c.Free()
+		b := make([]byte, 100)
+		n, err := c.Read(b)
+		require.ErrorIs(t, err, ErrEof)
+		require.Equal(t, 0, n)
+	})
 }
 
 func TestOpenIOContext(t *testing.T) {


### PR DESCRIPTION
At present, there's no mapping between the io.EOF returned by os.File or most io.Reader implementations and the astiav / ffmpeg ErrEof (C.AVERROR_EOF).

This PR adds a mapping in the event io.EOF is returned by the custom reader implementation.