### PR TITLE
Check if the frame is writable before copyPlanes

### DIFF
--- a/frame_data.go
+++ b/frame_data.go
@@ -284,6 +284,11 @@ func (f *frameDataFrame) copyPlanes(ps []frameDataPlane) (err error) {
 	switch {
 	// Video
 	case f.height() > 0 && f.width() > 0:
+		// Check writability
+		if !f.f.IsWritable() {
+			return errors.New("astiav: frame is not writable")
+		}
+
 		// Loop through planes
 		var cdata [8]*C.uint8_t
 		var clinesizes [8]C.int

--- a/frame_data.go
+++ b/frame_data.go
@@ -280,15 +280,15 @@ func (f *frameDataFrame) bytes(align int) ([]byte, error) {
 	return nil, errors.New("astiav: frame type not implemented")
 }
 
-func (f *frameDataFrame) copyPlanes(ps []frameDataPlane) (err error) {
+func (f *frameDataFrame) copyPlanes(ps []frameDataPlane) error {
+	// Check writability
+	if !f.f.IsWritable() {
+		return errors.New("astiav: frame is not writable")
+	}
+
 	switch {
 	// Video
 	case f.height() > 0 && f.width() > 0:
-		// Check writability
-		if !f.f.IsWritable() {
-			return errors.New("astiav: frame is not writable")
-		}
-
 		// Loop through planes
 		var cdata [8]*C.uint8_t
 		var clinesizes [8]C.int
@@ -305,9 +305,9 @@ func (f *frameDataFrame) copyPlanes(ps []frameDataPlane) (err error) {
 
 		// Copy image
 		C.av_image_copy(&f.f.c.data[0], &f.f.c.linesize[0], &cdata[0], &clinesizes[0], (C.enum_AVPixelFormat)(f.f.c.format), f.f.c.width, f.f.c.height)
-		return
+		return nil
 	}
-	return
+	return nil
 }
 
 func (f *frameDataFrame) height() int {

--- a/frame_data_test.go
+++ b/frame_data_test.go
@@ -518,5 +518,14 @@ func TestFrameData(t *testing.T) {
 		require.NoError(t, err)
 		b9 := []byte(fmt.Sprintf("%+v", b8))
 		require.Equal(t, b3, b9)
+
+		f3 := AllocFrame()
+		defer f3.Free()
+		require.NoError(t, f3.Ref(f2))
+		require.Error(t, fd2.FromImage(i1))
+		require.Error(t, fd2.SetBytes(b1, align))
+		f3.MakeWritable()
+		require.NoError(t, fd2.FromImage(i1))
+		require.NoError(t, fd2.SetBytes(b1, align))
 	}
 }

--- a/frame_data_test.go
+++ b/frame_data_test.go
@@ -524,7 +524,7 @@ func TestFrameData(t *testing.T) {
 		require.NoError(t, f3.Ref(f2))
 		require.Error(t, fd2.FromImage(i1))
 		require.Error(t, fd2.SetBytes(b1, align))
-		f3.MakeWritable()
+		f2.MakeWritable()
 		require.NoError(t, fd2.FromImage(i1))
 		require.NoError(t, fd2.SetBytes(b1, align))
 	}


### PR DESCRIPTION
For safety of frame operations, check if the frame is writable before copyPlanes.

If this seems to be a performance overhead, I would like input as this PR may not be necessary.