### PR TITLE
Create hardware device context with flags

### DIFF
--- a/examples/hardware_decoding/main.go
+++ b/examples/hardware_decoding/main.go
@@ -133,7 +133,7 @@ func main() {
 
 		// Create hardware device context
 		var err error
-		if s.hardwareDeviceContext, err = astiav.CreateHardwareDeviceContext(hardwareDeviceType, *hardwareDeviceName, nil); err != nil {
+		if s.hardwareDeviceContext, err = astiav.CreateHardwareDeviceContext(hardwareDeviceType, *hardwareDeviceName, nil, 0); err != nil {
 			log.Fatal(fmt.Errorf("main: creating hardware device context failed: %w", err))
 		}
 

--- a/examples/hardware_encoding/main.go
+++ b/examples/hardware_encoding/main.go
@@ -49,7 +49,7 @@ func main() {
 	}
 
 	// Create hardware device context
-	hardwareDeviceContext, err := astiav.CreateHardwareDeviceContext(hardwareDeviceType, *hardwareDeviceName, nil)
+	hardwareDeviceContext, err := astiav.CreateHardwareDeviceContext(hardwareDeviceType, *hardwareDeviceName, nil, 0)
 	if err != nil {
 		log.Fatal(fmt.Errorf("main: creating hardware device context failed: %w", err))
 	}

--- a/hardware_device_context.go
+++ b/hardware_device_context.go
@@ -12,7 +12,7 @@ type HardwareDeviceContext struct {
 	c *C.AVBufferRef
 }
 
-func CreateHardwareDeviceContext(t HardwareDeviceType, device string, options *Dictionary) (*HardwareDeviceContext, error) {
+func CreateHardwareDeviceContext(t HardwareDeviceType, device string, options *Dictionary, flags int) (*HardwareDeviceContext, error) {
 	hdc := HardwareDeviceContext{}
 	deviceC := (*C.char)(nil)
 	if device != "" {
@@ -23,7 +23,7 @@ func CreateHardwareDeviceContext(t HardwareDeviceType, device string, options *D
 	if options != nil {
 		optionsC = options.c
 	}
-	if err := newError(C.av_hwdevice_ctx_create(&hdc.c, (C.enum_AVHWDeviceType)(t), deviceC, optionsC, 0)); err != nil {
+	if err := newError(C.av_hwdevice_ctx_create(&hdc.c, (C.enum_AVHWDeviceType)(t), deviceC, optionsC, C.int(flags))); err != nil {
 		return nil, err
 	}
 	return &hdc, nil


### PR DESCRIPTION
Despite the official doc claiming that the flags are not used (see: [hwcontext.c File Reference](https://www.ffmpeg.org/doxygen/3.2/hwcontext_8c.html#a21fbd088225e4e25c4d9a01b3f5e8c51)), it is in reality used by `AVCUDADeviceContext` (see: [hwcontext_cuda.h](https://github.com/FFmpeg/FFmpeg/blob/df00705e0010cc2c53d17d51944f847c2c852189/libavutil/hwcontext_cuda.h#L53)).