### PR TITLE
Expose pointer to underlying AVCodecContext

### DIFF
--- a/codec_context.go
+++ b/codec_context.go
@@ -340,6 +340,10 @@ func (cc *CodecContext) SetExtraHardwareFrames(n int) {
 	cc.c.extra_hw_frames = C.int(n)
 }
 
+func (cc *CodecContext) UnsafePointer() unsafe.Pointer {
+	return unsafe.Pointer(cc.c)
+}
+
 type CodecContextPixelFormatCallback func(pfs []PixelFormat) PixelFormat
 
 var (

--- a/codec_context_test.go
+++ b/codec_context_test.go
@@ -2,6 +2,7 @@ package astiav
 
 import (
 	"testing"
+	"unsafe"
 
 	"github.com/stretchr/testify/require"
 )
@@ -40,6 +41,7 @@ func TestCodecContext(t *testing.T) {
 	require.Equal(t, 1, cc1.ThreadCount())
 	require.Equal(t, ThreadType(3), cc1.ThreadType())
 	require.Equal(t, 320, cc1.Width())
+	require.Equal(t, unsafe.Pointer(cc1.c), cc1.UnsafePointer())
 	cl := cc1.Class()
 	require.NotNil(t, cl)
 	require.Equal(t, "AVCodecContext", cl.Name())


### PR DESCRIPTION
In fact, I propose adding similar methods to all C wrapper structs for better interoperability with client codes. Also, a reciprocal method/function to convert client's `unsafe.Pointer`s to their corresponding `go-astiav` bindings.