### PR TITLE
codec_context.go and format_context.go

### DIFF
--- a/codec_context.go
+++ b/codec_context.go
@@ -390,6 +390,10 @@ func (cc *CodecContext) SetHardwareFrameContext(hfc *HardwareFrameContext) {
 	}
 }
 
+func (cc *CodecContext) HardwareFrameContext() *HardwareFrameContext{
+	return newHardwareFrameContextFromC(cc.c.hw_frames_ctx)
+}
+
 // https://ffmpeg.org/doxygen/7.0/structAVCodecContext.html#ad2f772bd948d8f3be4d674a3a52ee00e
 func (cc *CodecContext) ExtraHardwareFrames() int {
 	return int(cc.c.extra_hw_frames)

--- a/codec_context.go
+++ b/codec_context.go
@@ -380,6 +380,11 @@ func (cc *CodecContext) SetHardwareDeviceContext(hdc *HardwareDeviceContext) {
 }
 
 // https://ffmpeg.org/doxygen/7.0/structAVCodecContext.html#a3bac44bb0b016ab838780cc19ac277d6
+func (cc *CodecContext) HardwareFrameContext() *HardwareFrameContext {
+	return newHardwareFrameContextFromC(cc.c.hw_frames_ctx)
+}
+
+// https://ffmpeg.org/doxygen/7.0/structAVCodecContext.html#a3bac44bb0b016ab838780cc19ac277d6
 func (cc *CodecContext) SetHardwareFrameContext(hfc *HardwareFrameContext) {
 	if cc.hfc != nil {
 		C.av_buffer_unref(&cc.hfc.c)
@@ -388,10 +393,6 @@ func (cc *CodecContext) SetHardwareFrameContext(hfc *HardwareFrameContext) {
 	if cc.hfc != nil {
 		cc.c.hw_frames_ctx = C.av_buffer_ref(cc.hfc.c)
 	}
-}
-
-func (cc *CodecContext) HardwareFrameContext() *HardwareFrameContext{
-	return newHardwareFrameContextFromC(cc.c.hw_frames_ctx)
 }
 
 // https://ffmpeg.org/doxygen/7.0/structAVCodecContext.html#ad2f772bd948d8f3be4d674a3a52ee00e

--- a/format_context.go
+++ b/format_context.go
@@ -366,13 +366,11 @@ func (fc *FormatContext) FindBestStream(mt MediaType, wantedStreamIndex, related
 }
 
 // https://ffmpeg.org/doxygen/7.0/group__lavf__misc.html#gae2645941f2dc779c307eb6314fd39f10
-// prints detailed information about the input or output format, such as
-// duration, bitrate, streams, container, programs, metadata, side data, codec and time base.
 func (fc *FormatContext) DumpFormat(index int32, url string, isOutput int32) {
-	urlc := (*C.char)(nil)
+	curl := (*C.char)(nil)
 	if len(url) > 0 {
-		urlc = C.CString(url)
-		defer C.free(unsafe.Pointer(urlc))
+		curl = C.CString(url)
+		defer C.free(unsafe.Pointer(curl))
 	}
-	C.av_dump_format(fc.c, C.int(index), urlc, C.int(isOutput))
+	C.av_dump_format(fc.c, C.int(index), curl, C.int(isOutput))
 }

--- a/format_context.go
+++ b/format_context.go
@@ -366,11 +366,11 @@ func (fc *FormatContext) FindBestStream(mt MediaType, wantedStreamIndex, related
 }
 
 // https://ffmpeg.org/doxygen/7.0/group__lavf__misc.html#gae2645941f2dc779c307eb6314fd39f10
-func (fc *FormatContext) DumpFormat(index int32, url string, isOutput int32) {
+func (fc *FormatContext) Dump(streamIndex int, url string, isOutput bool) {
 	curl := (*C.char)(nil)
 	if len(url) > 0 {
 		curl = C.CString(url)
 		defer C.free(unsafe.Pointer(curl))
 	}
-	C.av_dump_format(fc.c, C.int(index), curl, C.int(isOutput))
+	C.av_dump_format(fc.c, C.int(streamIndex), curl, C.int(isOutput))
 }

--- a/format_context.go
+++ b/format_context.go
@@ -364,3 +364,15 @@ func (fc *FormatContext) FindBestStream(mt MediaType, wantedStreamIndex, related
 	}
 	return nil, nil, fmt.Errorf("astiav: no stream with index %d", ret)
 }
+
+// https://ffmpeg.org/doxygen/7.0/group__lavf__misc.html#gae2645941f2dc779c307eb6314fd39f10
+// prints detailed information about the input or output format, such as
+// duration, bitrate, streams, container, programs, metadata, side data, codec and time base.
+func (fc *FormatContext) DumpFormat(index int32, url string, isOutput int32) {
+	urlc := (*C.char)(nil)
+	if len(url) > 0 {
+		urlc = C.CString(url)
+		defer C.free(unsafe.Pointer(urlc))
+	}
+	C.av_dump_format(fc.c, C.int(index), urlc, C.int(isOutput))
+}

--- a/format_context.go
+++ b/format_context.go
@@ -372,5 +372,9 @@ func (fc *FormatContext) Dump(streamIndex int, url string, isOutput bool) {
 		curl = C.CString(url)
 		defer C.free(unsafe.Pointer(curl))
 	}
-	C.av_dump_format(fc.c, C.int(streamIndex), curl, C.int(isOutput))
+	cisOutput := 0
+	if isOutput {
+		cisOutput = 1
+	}
+	C.av_dump_format(fc.c, C.int(streamIndex), curl, C.int(cisOutput))
 }

--- a/format_context_test.go
+++ b/format_context_test.go
@@ -1,6 +1,7 @@
 package astiav
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -31,9 +32,18 @@ func TestFormatContext(t *testing.T) {
 	require.NotNil(t, cl)
 	require.Equal(t, "AVFormatContext", cl.Name())
 
-	sdp, err := fc1.SDPCreate()
-	require.NoError(t, err)
-	require.Equal(t, "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=Big Buck Bunny\r\nt=0 0\r\na=tool:libavformat 61.1.100\r\nm=video 0 RTP/AVP 96\r\nb=AS:441\r\na=rtpmap:96 H264/90000\r\na=fmtp:96 packetization-mode=1; sprop-parameter-sets=Z0LADasgKDPz4CIAAAMAAgAAAwBhHihUkA==,aM48gA==; profile-level-id=42C00D\r\na=control:streamid=0\r\nm=audio 0 RTP/AVP 97\r\nb=AS:161\r\na=rtpmap:97 MPEG4-GENERIC/48000/2\r\na=fmtp:97 profile-level-id=1;mode=AAC-hbr;sizelength=13;indexlength=3;indexdeltalength=3; config=1190\r\na=control:streamid=1\r\n", sdp)
+	//sdp, err := fc1.SDPCreate()
+	//require.NoError(t, err)
+	//require.Equal(t, "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=Big Buck Bunny\r\nt=0 0\r\na=tool:libavformat 61.1.100\r\nm=video 0 RTP/AVP 96\r\nb=AS:441\r\na=rtpmap:96 H264/90000\r\na=fmtp:96 packetization-mode=1; sprop-parameter-sets=Z0LADasgKDPz4CIAAAMAAgAAAwBhHihUkA==,aM48gA==; profile-level-id=42C00D\r\na=control:streamid=0\r\nm=audio 0 RTP/AVP 97\r\nb=AS:161\r\na=rtpmap:97 MPEG4-GENERIC/48000/2\r\na=fmtp:97 profile-level-id=1;mode=AAC-hbr;sizelength=13;indexlength=3;indexdeltalength=3; config=1190\r\na=control:streamid=1\r\n", sdp)
+
+	SetLogLevel(LogLevelInfo)
+	SetLogCallback(func(c Classer, l LogLevel, f, msg string) {
+		msg = strings.TrimSpace(msg)
+		if strings.HasPrefix(msg, "Stream") && strings.Contains(msg, "Video") {
+			require.Equal(t, msg, `Stream #0:0[0x1](und): Video: h264 (Constrained Baseline) (avc1 / 0x31637661), yuv420p(progressive), 320x180 [SAR 1:1 DAR 16:9], 441 kb/s, 24 fps, 24 tbr, 12288 tbn (default)`)
+		}
+	})
+	fc1.Dump(0, "video.mp4", false)
 
 	_, _, err = fc1.FindBestStream(MediaTypeUnknown, -1, -1)
 	require.Error(t, err)

--- a/format_context_test.go
+++ b/format_context_test.go
@@ -32,9 +32,9 @@ func TestFormatContext(t *testing.T) {
 	require.NotNil(t, cl)
 	require.Equal(t, "AVFormatContext", cl.Name())
 
-	//sdp, err := fc1.SDPCreate()
-	//require.NoError(t, err)
-	//require.Equal(t, "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=Big Buck Bunny\r\nt=0 0\r\na=tool:libavformat 61.1.100\r\nm=video 0 RTP/AVP 96\r\nb=AS:441\r\na=rtpmap:96 H264/90000\r\na=fmtp:96 packetization-mode=1; sprop-parameter-sets=Z0LADasgKDPz4CIAAAMAAgAAAwBhHihUkA==,aM48gA==; profile-level-id=42C00D\r\na=control:streamid=0\r\nm=audio 0 RTP/AVP 97\r\nb=AS:161\r\na=rtpmap:97 MPEG4-GENERIC/48000/2\r\na=fmtp:97 profile-level-id=1;mode=AAC-hbr;sizelength=13;indexlength=3;indexdeltalength=3; config=1190\r\na=control:streamid=1\r\n", sdp)
+	sdp, err := fc1.SDPCreate()
+	require.NoError(t, err)
+	require.Equal(t, "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=Big Buck Bunny\r\nt=0 0\r\na=tool:libavformat 61.1.100\r\nm=video 0 RTP/AVP 96\r\nb=AS:441\r\na=rtpmap:96 H264/90000\r\na=fmtp:96 packetization-mode=1; sprop-parameter-sets=Z0LADasgKDPz4CIAAAMAAgAAAwBhHihUkA==,aM48gA==; profile-level-id=42C00D\r\na=control:streamid=0\r\nm=audio 0 RTP/AVP 97\r\nb=AS:161\r\na=rtpmap:97 MPEG4-GENERIC/48000/2\r\na=fmtp:97 profile-level-id=1;mode=AAC-hbr;sizelength=13;indexlength=3;indexdeltalength=3; config=1190\r\na=control:streamid=1\r\n", sdp)
 
 	SetLogLevel(LogLevelInfo)
 	SetLogCallback(func(c Classer, l LogLevel, f, msg string) {


### PR DESCRIPTION
codec_context.go
`
func (cc *CodecContext) HardwareFrameContext() *HardwareFrameContext{
	return newHardwareFrameContextFromC(cc.c.hw_frames_ctx)
}
`
format_context.go
`
func (fc *FormatContext) DumpFormat(index int32, url string, isOutput int32) {
	urlc := (*C.char)(nil)
	if len(url) > 0 {
		urlc = C.CString(url)
		defer C.free(unsafe.Pointer(urlc))
	}
	C.av_dump_format(fc.c, C.int(index), urlc, C.int(isOutput))
}
`