### PR TITLE
packet: Add memory management *Packet functions

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -120,6 +120,25 @@ func (p *Packet) Clone() *Packet {
 	return newPacketFromC(C.av_packet_clone(p.c))
 }
 
+// https://ffmpeg.org/doxygen/7.0/group__lavc__packet.html#gade00f67930f4e2a3401b67b701d5b3a2
+func (p *Packet) CopyProperties(src *Packet) error {
+	return newError(C.av_packet_copy_props(p.c, src.c))
+}
+
+// https://ffmpeg.org/doxygen/7.0/group__lavc__packet.html#ga8a6deff6c1809029037ffd760db3e0d4
+func (p *Packet) MakeReferenceCounted() error {
+	return newError(C.av_packet_make_refcounted(p.c))
+}
+
+// https://ffmpeg.org/doxygen/7.0/group__lavc__packet.html#gaaa304ffdab83984ac995d134e4298d4b
+func (p *Packet) MakeWritable() error {
+	return newError(C.av_packet_make_writable(p.c))
+}
+
+func (p *Packet) IsWritable() bool {
+	return p.c.buf != nil && C.av_buffer_is_writable(p.c.buf) != 0
+}
+
 // https://ffmpeg.org/doxygen/7.0/group__lavc__packet.html#gadfa708660b85a56749c753124de2da7d
 func (p *Packet) AllocPayload(s int) error {
 	return newError(C.av_new_packet(p.c, C.int(s)))

--- a/packet_test.go
+++ b/packet_test.go
@@ -85,4 +85,22 @@ func TestPacket(t *testing.T) {
 	b = []byte{}
 	require.NoError(t, pkt6.FromData(b))
 	require.Equal(t, b, pkt6.Data())
+
+	pkt7 := AllocPacket()
+	require.NotNil(t, pkt7)
+	defer pkt7.Free()
+
+	require.NotEqual(t, pkt2.Dts(), pkt7.Dts())
+	require.NoError(t, pkt7.CopyProperties(pkt2))
+	require.Equal(t, pkt2.Dts(), pkt7.Dts())
+
+	pkt8 := pkt2.Clone()
+	defer pkt8.Free()
+	require.False(t, pkt8.IsWritable())
+	require.NoError(t, pkt8.MakeWritable())
+	require.True(t, pkt8.IsWritable())
+
+	pkt9 := pkt2.Clone()
+	defer pkt9.Free()
+	require.NoError(t, pkt9.MakeReferenceCounted())
 }


### PR DESCRIPTION
* Function `(*Packet).CopyProps` is a wrapper for av_packet_copy_props It copes field values from one Packet to another. See: https://ffmpeg.org/doxygen/7.0/group__lavc__packet.html#gade00f67930f4e2a3401b67b701d5b3a2

* Function `(*Packet).MakeRefcounted` is a wrapper for av_packet_make_refcounted It makes sure the packet data is reference counted (in contrast to duplicated) See: https://ffmpeg.org/doxygen/7.0/group__lavc__packet.html#ga8a6deff6c1809029037ffd760db3e0d4

* Function `(*Packet).MakeWritable` is a wrapper for av_packet_make_writable It makes sure the packet data is writable (in contrast to reference counted) See: https://ffmpeg.org/doxygen/7.0/group__lavc__packet.html#gaaa304ffdab83984ac995d134e4298d4b