### PR TITLE
Add AV1 codec id

### DIFF
--- a/codec_id.go
+++ b/codec_id.go
@@ -413,6 +413,7 @@ const (
 	CodecIDZerocodec                = CodecID(C.AV_CODEC_ID_ZEROCODEC)
 	CodecIDZlib                     = CodecID(C.AV_CODEC_ID_ZLIB)
 	CodecIDZmbv                     = CodecID(C.AV_CODEC_ID_ZMBV)
+	CodecIDAv1                      = CodecID(C.AV_CODEC_ID_AV1)
 )
 
 func (c CodecID) MediaType() MediaType {

--- a/codec_id.go
+++ b/codec_id.go
@@ -73,6 +73,7 @@ const (
 	CodecIDAtrac3P                  = CodecID(C.AV_CODEC_ID_ATRAC3P)
 	CodecIDAura                     = CodecID(C.AV_CODEC_ID_AURA)
 	CodecIDAura2                    = CodecID(C.AV_CODEC_ID_AURA2)
+	CodecIDAv1                      = CodecID(C.AV_CODEC_ID_AV1)
 	CodecIDAvrn                     = CodecID(C.AV_CODEC_ID_AVRN)
 	CodecIDAvrp                     = CodecID(C.AV_CODEC_ID_AVRP)
 	CodecIDAvs                      = CodecID(C.AV_CODEC_ID_AVS)
@@ -413,7 +414,6 @@ const (
 	CodecIDZerocodec                = CodecID(C.AV_CODEC_ID_ZEROCODEC)
 	CodecIDZlib                     = CodecID(C.AV_CODEC_ID_ZLIB)
 	CodecIDZmbv                     = CodecID(C.AV_CODEC_ID_ZMBV)
-	CodecIDAv1                      = CodecID(C.AV_CODEC_ID_AV1)
 )
 
 func (c CodecID) MediaType() MediaType {


### PR DESCRIPTION
@asticode Hi first of all, thanks for this great library! I'm currently using this to decode av1 video stream, and I found that AV1 codec id is not included in `codec_id.go`.

Perhaps in the future, a script or something can be made to generate `codec_id.go` from `libavcodec/codec_id.h`? I'd love to do that if you think it would be helpful.