### PR TITLE
Add json compatible encoding for core types

### DIFF
--- a/channel_layout.go
+++ b/channel_layout.go
@@ -3,6 +3,7 @@ package astiav
 //#include "channel_layout.h"
 import "C"
 import (
+	"fmt"
 	"unsafe"
 )
 
@@ -122,4 +123,26 @@ func (l ChannelLayout) clone() (ChannelLayout, error) {
 	err := l.copy(&cl)
 	dst := newChannelLayoutFromC(&cl)
 	return dst, err
+}
+
+func ParseChannelLayout(s string) (ChannelLayout, error) {
+	var c C.AVChannelLayout
+	cn := C.CString(s)
+	defer C.free(unsafe.Pointer(cn))
+	id := C.av_channel_layout_from_string(&c, cn)
+	return newChannelLayoutFromC(&c), newError(id)
+}
+
+func (l ChannelLayout) MarshalText() ([]byte, error) { return ([]byte)(l.String()), nil }
+func (l *ChannelLayout) UnmarshalText(d []byte) error {
+	s := string(d)
+	if s == "" {
+		return nil
+	}
+	pf, err := ParseChannelLayout(s)
+	if err != nil {
+		return fmt.Errorf("invalid Channel Layout: %s: %w", s, err)
+	}
+	l.c = pf.c
+	return nil
 }

--- a/channel_layout_test.go
+++ b/channel_layout_test.go
@@ -7,17 +7,36 @@ import (
 )
 
 func TestChannelLayout(t *testing.T) {
-	cl1 := ChannelLayoutStereo
-	require.Equal(t, 2, cl1.Channels())
-	require.Equal(t, "stereo", cl1.String())
-	require.True(t, cl1.Valid())
-	require.True(t, cl1.Equal(ChannelLayoutStereo))
-	require.False(t, cl1.Equal(ChannelLayoutMono))
-	cl2 := ChannelLayout{}
-	require.Equal(t, 0, cl2.Channels())
-	require.False(t, cl2.Valid())
-	require.Equal(t, "", cl2.String())
-	require.False(t, cl1.Equal(cl2))
-	cl3 := ChannelLayout{}
-	require.True(t, cl2.Equal(cl3))
+	t.Run("Actual", func(t *testing.T) {
+		cl1 := ChannelLayoutStereo
+		require.Equal(t, 2, cl1.Channels())
+		require.Equal(t, "stereo", cl1.String())
+		require.True(t, cl1.Valid())
+		require.True(t, cl1.Equal(ChannelLayoutStereo))
+		require.False(t, cl1.Equal(ChannelLayoutMono))
+	})
+	t.Run("Empty", func(t *testing.T) {
+		cl2 := ChannelLayout{}
+		require.Equal(t, 0, cl2.Channels())
+		require.False(t, cl2.Valid())
+		require.Equal(t, "", cl2.String())
+		require.False(t, cl2.Equal(ChannelLayoutStereo))
+		cl3 := ChannelLayout{}
+		require.True(t, cl2.Equal(cl3))
+	})
+	t.Run("Parse", func(t *testing.T) {
+		cl1 := ChannelLayoutStereo
+		ls := cl1.String()
+		cl2, err := ParseChannelLayout(ls)
+		require.NoError(t, err)
+		require.True(t, cl1.Equal(cl2))
+	})
+	t.Run("TextMarshal", func(t *testing.T) {
+		x1 := ChannelLayoutStereo
+		s, err := x1.MarshalText()
+		require.NoError(t, err)
+		var x2 ChannelLayout
+		require.NoError(t, x2.UnmarshalText(s))
+		require.True(t, x1.Equal(x2))
+	})
 }

--- a/log.go
+++ b/log.go
@@ -22,6 +22,27 @@ const (
 	LogLevelDebug   = LogLevel(C.AV_LOG_DEBUG)
 )
 
+func (l LogLevel) String() string {
+	switch l {
+	case LogLevelPanic:
+		return "PANIC"
+	case LogLevelFatal:
+		return "FATAL"
+	case LogLevelError:
+		return "ERROR"
+	case LogLevelWarning:
+		return "WARNING"
+	case LogLevelInfo:
+		return "INFO"
+	case LogLevelVerbose:
+		return "VERBOSE"
+	case LogLevelDebug:
+		return "DEBUG"
+	default:
+		return "UNKNOWN"
+	}
+}
+
 // https://ffmpeg.org/doxygen/7.0/group__lavu__log.html#ga1fd32c74db581e3e2e7f35d277bb1e24
 func SetLogLevel(l LogLevel) {
 	C.av_log_set_level(C.int(l))

--- a/pixel_format_test.go
+++ b/pixel_format_test.go
@@ -7,10 +7,23 @@ import (
 )
 
 func TestPixelFormat(t *testing.T) {
-	p := FindPixelFormatByName("yuv420p")
-	require.Equal(t, PixelFormatYuv420P, p)
-	require.Equal(t, "yuv420p", p.String())
 	d := p.Descriptor()
 	require.NotNil(t, d)
 	require.Equal(t, d.Name(), p.String())
+	p := FindPixelFormatByName("yuv420p")
+	require.Equal(t, PixelFormatYuv420P, p)
+	require.Equal(t, "yuv420p", p.String())
+	t.Run("FindByName", func(t *testing.T) {
+		p := FindPixelFormatByName("yuv420p")
+		require.Equal(t, PixelFormatYuv420P, p)
+		require.Equal(t, "yuv420p", p.String())
+	})
+	t.Run("Encode", func(t *testing.T) {
+		x1 := PixelFormatAbgr
+		s, err := x1.MarshalText()
+		require.NoError(t, err)
+		var x2 PixelFormat
+		require.NoError(t, x2.UnmarshalText(s))
+		require.Equal(t, x1, x2)
+	})
 }

--- a/rational.go
+++ b/rational.go
@@ -2,12 +2,23 @@ package astiav
 
 //#include <libavutil/rational.h>
 import "C"
-import "strconv"
+import (
+	"encoding"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
 
 // https://ffmpeg.org/doxygen/7.0/structAVRational.html
 type Rational struct {
 	c C.AVRational
 }
+
+var _ json.Marshaler = (*Rational)(nil)
+var _ json.Unmarshaler = (*Rational)(nil)
+var _ encoding.TextMarshaler = (*Rational)(nil)
+var _ encoding.TextUnmarshaler = (*Rational)(nil)
 
 func newRationalFromC(c C.AVRational) Rational {
 	return Rational{c: c}
@@ -52,4 +63,47 @@ func (r Rational) String() string {
 
 func (r Rational) Invert() Rational {
 	return NewRational(r.Den(), r.Num())
+}
+
+type rational struct {
+	Num int
+	Den int
+}
+
+func (r *Rational) UnmarshalJSON(d []byte) error {
+	var rs rational
+	if err := json.Unmarshal(d, &rs); err != nil {
+		return err
+	}
+	r.SetNum(rs.Num)
+	r.SetDen(rs.Den)
+	return nil
+}
+
+func (r Rational) MarshalJSON() ([]byte, error) {
+	return json.Marshal(rational{Num: r.Num(), Den: r.Den()})
+}
+
+func (r Rational) MarshalText() ([]byte, error) { return ([]byte)(r.String()), nil }
+func (r *Rational) UnmarshalText(d []byte) error {
+	s := string(d)
+	if s == "" {
+		r.SetNum(0)
+		r.SetDen(0)
+	}
+	parts := strings.Split(s, "/")
+	if len(parts) != 2 {
+		return fmt.Errorf("value %s is not Rational ('d/d')", s)
+	}
+	num, err := strconv.ParseInt(parts[0], 10, 0)
+	if err != nil {
+		return fmt.Errorf("value %s is not Rational ('d/d'): %w", s, err)
+	}
+	den, err := strconv.ParseInt(parts[1], 10, 0)
+	if err != nil {
+		return fmt.Errorf("value %s is not Rational ('d/d'): %w", s, err)
+	}
+	r.SetNum(int(num))
+	r.SetDen(int(den))
+	return nil
 }

--- a/rational_test.go
+++ b/rational_test.go
@@ -1,23 +1,57 @@
 package astiav
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestRational(t *testing.T) {
-	r := NewRational(2, 1)
-	require.Equal(t, 2, r.Num())
-	require.Equal(t, 1, r.Den())
-	require.Equal(t, 0.5, r.Invert().Float64())
-	r.SetNum(1)
-	r.SetDen(2)
-	require.Equal(t, 1, r.Num())
-	require.Equal(t, 2, r.Den())
-	require.Equal(t, "1/2", r.String())
-	require.Equal(t, 0.5, r.Float64())
-	r.SetDen(0)
-	require.Equal(t, float64(0), r.Float64())
-	require.Equal(t, "0", r.String())
+	t.Run("New", func(t *testing.T) {
+		r := NewRational(2, 1)
+		require.Equal(t, 2, r.Num())
+		require.Equal(t, 1, r.Den())
+		require.Equal(t, 0.5, r.Invert().Float64())
+	})
+	t.Run("Set", func(t *testing.T) {
+		r := NewRational(0, 0)
+		r.SetNum(1)
+		r.SetDen(2)
+		require.Equal(t, 1, r.Num())
+		require.Equal(t, 2, r.Den())
+	})
+	t.Run("Float", func(t *testing.T) {
+		r := NewRational(0, 0)
+		require.Equal(t, 0.0, r.Float64())
+		r = NewRational(2, 1)
+		require.Equal(t, 2.0, r.Float64())
+		r = NewRational(1, 2)
+		require.Equal(t, 0.5, r.Float64())
+	})
+	t.Run("String", func(t *testing.T) {
+		r := NewRational(2, 1)
+		require.Equal(t, "2/1", r.String())
+	})
+	t.Run("TextMarshal", func(t *testing.T) {
+		r := NewRational(2, 1)
+		s, err := r.MarshalText()
+		require.NoError(t, err)
+		var r2 Rational
+		require.NoError(t, r2.UnmarshalText(s))
+		require.Equal(t, r.Num(), r2.Num())
+		require.Equal(t, r.Den(), r2.Den())
+	})
+	t.Run("json.Marshal", func(t *testing.T) {
+		type test struct {
+			Timebase Rational
+		}
+		x1 := test{Timebase: NewRational(2, 1)}
+		data, err := json.Marshal(x1)
+		require.NoError(t, err)
+		x2 := test{}
+		require.NoError(t, json.Unmarshal(data, &x2))
+		require.Equal(t, x1.Timebase.Num(), x2.Timebase.Num())
+		require.Equal(t, x1.Timebase.Den(), x2.Timebase.Den())
+	})
 }


### PR DESCRIPTION
Update Rational, PixelFormat and ChannelLayout to implement json interfaces which allow serializing these types to JSON without intermediate parser steps

Also add names for levels so the level name can be printed using fmt.Printf("%s")