### PR TITLE
feat: add dictionary seq method

### DIFF
--- a/dictionary.go
+++ b/dictionary.go
@@ -5,6 +5,7 @@ package astiav
 //#include <stdlib.h>
 import "C"
 import (
+	"iter"
 	"unsafe"
 )
 
@@ -82,4 +83,25 @@ func (d *Dictionary) Unpack(b []byte) error {
 // https://ffmpeg.org/doxygen/8.0/group__lavu__dict.html#ga59a6372b124b306e3a2233723c5cdc78
 func (d *Dictionary) Copy(dst *Dictionary, flags DictionaryFlags) error {
 	return newError(C.av_dict_copy(&dst.c, d.c, C.int(flags)))
+}
+
+// Seq returns an iterator ([iter.Seq2]) over the key-value pairs in an [Dictionary].
+//
+// It provides a convenient way to iterate over FFmpeg's metadata dictionaries (AVDictionary).
+func (d *Dictionary) Seq() iter.Seq2[string, string] {
+	return func(yield func(string, string) bool) {
+		flags := DictionaryFlags(DictionaryFlagIgnoreSuffix)
+		var entry *DictionaryEntry
+
+		for {
+			entry = d.Get("", entry, flags)
+			if entry == nil {
+				return
+			}
+
+			if !yield(entry.Key(), entry.Value()) {
+				return
+			}
+		}
+	}
 }

--- a/dictionary_test.go
+++ b/dictionary_test.go
@@ -1,6 +1,7 @@
 package astiav
 
 import (
+	"maps"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -48,4 +49,20 @@ func TestDictionary(t *testing.T) {
 	require.Equal(t, "k4", e.Key())
 	require.Equal(t, "v4", e.Value())
 
+	d3 := NewDictionary()
+	defer d3.Free()
+	err = d3.Set("k1", "v1", 0)
+	require.NoError(t, err)
+	err = d3.Set("k2", "v2", 0)
+	require.NoError(t, err)
+	err = d3.Set("k3", "v3", 0)
+	require.NoError(t, err)
+
+	m1 := maps.Collect(d3.Seq())
+	m2 := map[string]string{
+		"k1": "v1",
+		"k2": "v2",
+		"k3": "v3",
+	}
+	require.Equal(t, m1, m2)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/asticode/go-astiav
 
-go 1.21
+go 1.23
 
 require (
 	github.com/asticode/go-astikit v0.42.0


### PR DESCRIPTION
Add a Seq method to Dictionary to allow iterating over the key-value pairs. Needs at least go1.23.