### PR TITLE
feat: add ProfileName to CodecParameters to get the full profile name.

### DIFF
--- a/codec_parameters.go
+++ b/codec_parameters.go
@@ -173,12 +173,7 @@ func (cp *CodecParameters) SetProfile(p Profile) {
 
 // https://ffmpeg.org/doxygen/8.0/group__lavc__core.html#ga7f9d1f2fbf0978fc1ddc2fe196f29fa4
 func (cp *CodecParameters) ProfileName() string {
-	name := C.avcodec_profile_name(cp.c.codec_id, cp.c.profile)
-	if name != nil {
-		return C.GoString(name)
-	} else {
-		return ""
-	}
+	return C.GoString(C.avcodec_profile_name(cp.c.codec_id, cp.c.profile))
 }
 
 // https://ffmpeg.org/doxygen/8.0/structAVCodecParameters.html#a7d6ef91120ffe80040c699e747a1ad68

--- a/codec_parameters.go
+++ b/codec_parameters.go
@@ -171,6 +171,16 @@ func (cp *CodecParameters) SetProfile(p Profile) {
 	cp.c.profile = C.int(p)
 }
 
+// https://ffmpeg.org/doxygen/8.0/group__lavc__core.html#ga7f9d1f2fbf0978fc1ddc2fe196f29fa4
+func (cp *CodecParameters) ProfileName() string {
+	name := C.avcodec_profile_name(cp.c.codec_id, cp.c.profile)
+	if name != nil {
+		return C.GoString(name)
+	} else {
+		return ""
+	}
+}
+
 // https://ffmpeg.org/doxygen/8.0/structAVCodecParameters.html#a7d6ef91120ffe80040c699e747a1ad68
 func (cp *CodecParameters) SampleAspectRatio() Rational {
 	return newRationalFromC(cp.c.sample_aspect_ratio)

--- a/codec_parameters_test.go
+++ b/codec_parameters_test.go
@@ -28,6 +28,7 @@ func TestCodecParameters(t *testing.T) {
 	require.Equal(t, MediaTypeVideo, cp1.MediaType())
 	require.Equal(t, PixelFormatYuv420P, cp1.PixelFormat())
 	require.Equal(t, ProfileH264ConstrainedBaseline, cp1.Profile())
+	require.Equal(t, "Constrained Baseline", cp1.ProfileName())
 	require.Equal(t, NewRational(1, 1), cp1.SampleAspectRatio())
 	require.Equal(t, 320, cp1.Width())
 
@@ -86,6 +87,7 @@ func TestCodecParameters(t *testing.T) {
 	require.Equal(t, MediaTypeAudio, cp6.MediaType())
 	cp1.SetProfile(ProfileH264Extended)
 	require.Equal(t, ProfileH264Extended, cp1.Profile())
+	require.Equal(t, "Extended", cp1.ProfileName())
 	cp6.SetPixelFormat(PixelFormat0Bgr)
 	require.Equal(t, PixelFormat0Bgr, cp6.PixelFormat())
 	cp6.SetSampleAspectRatio(NewRational(1, 2))


### PR DESCRIPTION
Add "ProfileName()" to CodecParameters to get the full profile name. Provides human readable string of the codec.