### PR TITLE
feat: expose probe score in format context

### DIFF
--- a/format_context.go
+++ b/format_context.go
@@ -204,6 +204,11 @@ func (fc *FormatContext) StartTime() int64 {
 	return int64(fc.c.start_time)
 }
 
+// https://ffmpeg.org/doxygen/8.0/structAVFormatContext.html#a65f11f94f40f83866ebe651c8ae111cf
+func (fc *FormatContext) ProbeScore() int {
+	return int(fc.c.probe_score)
+}
+
 // https://ffmpeg.org/doxygen/8.0/structAVFormatContext.html#a5017684cf0a84c990f60c8d50adec144
 func (fc *FormatContext) StrictStdCompliance() StrictStdCompliance {
 	return StrictStdCompliance(fc.c.strict_std_compliance)

--- a/format_context_test.go
+++ b/format_context_test.go
@@ -27,6 +27,7 @@ func TestFormatContext(t *testing.T) {
 	require.Equal(t, "isom", fc1.Metadata().Get("major_brand", nil, NewDictionaryFlags()).Value())
 	require.NotNil(t, fc1.PrivateData())
 	require.Equal(t, int64(0), fc1.StartTime())
+	require.Equal(t, 100, fc1.ProbeScore())
 	require.Equal(t, 2, fc1.NbStreams())
 	require.Len(t, fc1.Streams(), 2)
 	cl := fc1.Class()


### PR DESCRIPTION
Add ProbeScore to FormatContext to get "probe_score".